### PR TITLE
some tweaks to be able to build on a current buildsystem

### DIFF
--- a/reader/Makefile
+++ b/reader/Makefile
@@ -25,8 +25,8 @@ SOURCES := $(wildcard *.cpp) $(wildcard *.c)
 
 
 # Generic flags for the C/CPP compiler.
-CFLAGS := 			-pipe -O2 -Wall -D'APP_NAME="$(APP_NAME)"'
-CFLAGS_debug := 		-pipe -g -Wall -D'APP_NAME="$(APP_NAME)"' -D_DEBUG
+CFLAGS := 			-pipe -O2 -Wall -D'APP_NAME="$(APP_NAME)"' -std=gnu++98
+CFLAGS_debug := 		-pipe -g -Wall -D'APP_NAME="$(APP_NAME)"' -std=gnu++98 -D_DEBUG
 CXXFLAGS := 			$(CFLAGS)
 CXXFLAGS_debug := 		$(CFLAGS_debug)
 GCC := 				gcc

--- a/reader/navilock.cpp
+++ b/reader/navilock.cpp
@@ -17,6 +17,10 @@
 #include <cstring>
 #include <sstream>
 
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 
 #define IO_BUFFER_SIZE 128
 


### PR DESCRIPTION
had some compile errors due to c++ standard '11 and usleep includes
this fixes them and the project compiles successfully
feel free to integrate them
I'm happy to still be able to use your tool